### PR TITLE
Use semver range for SensESP dependency

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -14,7 +14,7 @@ upload_speed = 2000000
 monitor_speed = 115200
 
 lib_deps =
-    SignalK/SensESP @ 3.2.0
+    SignalK/SensESP @ ^3.2.0
     SensESP/NMEA0183 @ ^3.1.0
     adafruit/Adafruit SSD1306 @ ^2.5.1
     adafruit/Adafruit NeoPixel @ ^1.12


### PR DESCRIPTION
## Summary

- Change SensESP from exact pin (`@ 3.2.0`) to compatible range (`@ ^3.2.0`)

FastLED remains pinned at 3.9.4 — 3.10.x fails to build with this pioarduino platform version (designator order error in `idf5_i2s_context.hpp`).

## Test plan

- [x] `pio run` compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)