### PR TITLE
Add comprehensive documentation and code comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-HALSER AIS interface firmware — an ESP32-C3 firmware that bridges a Matsutec HA-102 AIS transponder to NMEA 2000 and Signal K networks via the HALSER board.
+HALSER AIS interface firmware — an ESP32-C3 firmware that bridges a Matsutec HA-102 AIS transponder to NMEA 2000 and Signal K networks via the HALSER board. Also serves as a reference implementation for SensESP-based marine interface firmware.
 
 ## Build Commands
 
@@ -15,6 +15,9 @@ pio run -t upload
 
 # Monitor serial output
 pio device monitor
+
+# Run unit tests (native platform)
+pio test -e native
 ```
 
 ## Architecture
@@ -22,26 +25,46 @@ pio device monitor
 ### Data Flow
 
 ```
-Matsutec HA-102 (NMEA 0183, 38400 bit/s, GPIO 3 RX / GPIO 2 TX)
+Matsutec HA-102 (NMEA 0183, 38,400 bit/s, GPIO 3 RX / GPIO 2 TX)
   → NMEA0183IOTask (dedicated FreeRTOS task)
-  → Matsutec parsers (MMSI, Static Ship Data, Voyage Data)
-  → TCP server (port 10110) for raw NMEA 0183 relay
-  → TCP client for Signal K server relay
-  → tNMEA2000_esp32 (TWAI, GPIO 4 TX / GPIO 5 RX)
-  → SSD1306 OLED display (I2C, GPIO 6 SDA / GPIO 7 SCL)
+    → Matsutec config parsers (MMSI, ship data, voyage data)
+    → RMC parser (GNSS time sync)
+    → AIS VDM/VDO parser
+      → AISReassembler (multi-part message assembly)
+        → AIS Decoder (6-bit binary → typed structs)
+          → N2K Senders → tNMEA2000_esp32 (TWAI, GPIO 4 TX / GPIO 5 RX)
+          → SK Output → Signal K server (per-vessel context)
+
+Web UI ←→ Config objects ←→ Matsutec (serial commands)
+Signal K server → SKValueListeners → Voyage data config → Matsutec
 ```
 
 ### Source Layout
 
-- `src/main.cpp` — Application entry point, wiring
-- `src/sender/n2k_senders.h` — N2K sender base class
-- `src/ssd1306_display.h/.cpp` — OLED display (hostname, IP, uptime)
-- `src/matsutec_ha102_parser.h` — Matsutec proprietary sentence parsers (MMSI, ship data, voyage data)
-- `src/matsutec_config.h` — Matsutec HA-102 configuration (MMSI, ship data, voyage data)
-- `src/streaming_tcp_server.h` — TCP server for raw NMEA 0183 relay
-- `src/streaming_tcp_client.h/.cpp` — TCP client for Signal K relay
-- `src/buffered_tcp_client.h` — TCP client with RX line buffer
-- `src/ui_config.h` — Port and host+port configuration UI controls
+**AIS Decoding** (`src/ais/`) — framework-agnostic, no Arduino/SensESP dependencies:
+- `ais_message_types.h` — Data structs for 6 AIS message types (Class A/B position, Class A/B static, safety, AtoN)
+- `ais_decoder.h/.cpp` — Binary payload decoding (ITU 6-bit armored characters → typed structs)
+- `ais_reassembler.h/.cpp` — Multi-part VDM sentence reassembly with 2-second timeout
+- `ais_vdm_fields.h` — VDM sentence field extraction and decode orchestration
+- `ais_vdm_parser.h` — SensESP `SentenceParser` integration; produces typed AIS message outputs for downstream consumers
+- `ais_conversions.h` — Unit conversions (heading, COG, SOG, ROT, dimensions, ETA) between AIS, N2K, and SI
+
+**Matsutec Configuration** (`src/`):
+- `matsutec_config.h` — Config objects (MMSIConfig, ShipDataConfig, VoyageStaticDataConfig) that query/set transponder state via proprietary NMEA 0183 sentences
+- `matsutec_ha102_parser.h` — SentenceParser subclasses for Matsutec response sentences (PAMC, AISSD, AIVSD)
+- `operating_mode.h` — Framework-agnostic TX/RX mode state machine (zero MMSI disables transmission)
+- `operating_mode_config.h` — SensESP Saveable/Serializable wrapper for operating mode
+
+**NMEA 2000 Output** (`src/sender/`):
+- `ais_n2k_senders.h` — ValueConsumer classes that convert AIS structs to N2K PGNs (129038, 129039, 129794, 129802, 129809, 129810, 129041)
+
+**Signal K Output** (`src/signalk/`):
+- `sk_ais_output.h` — Wires AIS parser outputs to Signal K contextual outputs (per-vessel/AtoN context by MMSI)
+- `sk_contextual_output.h` — SensESP extension: SKOutput with dynamic context (input is `pair<context, value>`)
+
+**Application** (`src/`):
+- `main.cpp` — Application entry point; initializes all components and wires the data pipeline
+- `ssd1306_display.h/.cpp` — OLED display driver (hostname, IP, uptime; updates every 1 second)
 
 ### Hardware Pin Assignments
 
@@ -56,25 +79,62 @@ Matsutec HA-102 (NMEA 0183, 38400 bit/s, GPIO 3 RX / GPIO 2 TX)
 | GPIO 8 | RGB LED (SK6805) |
 | GPIO 9 | Button |
 
-### Matsutec HA-102 Configuration
+### Matsutec HA-102 Protocol
 
-The transponder is configured via proprietary NMEA 0183 sentences:
-- `$PAMC,Q,MID` / `$PAMC,C,MID` — Query/set MMSI
-- `$ECAIQ,SSD` / `$AISSD` — Query/set static ship data
-- `$ECAIQ,VSD` / `$AIVSD` — Query/set voyage static data
+Configuration uses proprietary NMEA 0183 sentences:
 
-### TCP Server/Client
+**MMSI:**
+- Query: `$PAMC,Q,MID*xx` → Response: `$PAMC,R,MID,123456789,000000000*xx`
+- Set: `$PAMC,C,MID,123456789,000000000*xx` → Echo confirms
 
-- TCP server on port 10110 relays raw NMEA 0183 sentences to connected clients
-- TCP client connects to a Signal K server for NMEA 0183 data relay
-- Both are configurable (enable/disable, host, port) via web UI
+**Static ship data:**
+- Query: `$ECAIQ,SSD*xx` → Response: `$AISSD,CALLSGN,SHIPNAME,030,010,03,05,0,*xx`
+- Set: same format as response
+
+**Voyage static data:**
+- Query: `$ECAIQ,VSD*xx` → Response: `$AIVSD,36,2.2,2,DESTINATION,070000,15,06,0,0*xx`
+- Set: same format as response (fields: ship_type, draught, persons, dest, HHMMSS, day, month, nav_status, flags)
+
+**Operating mode:**
+- Receive-only: set MMSI to `000000000` (disables TX, preserves config)
+- Transmit+Receive: set MMSI to configured value
+
+### AIS Message Types Supported
+
+| Type | Description | N2K PGN |
+|------|-------------|---------|
+| 1, 2, 3 | Class A Position Report | 129038 |
+| 5 | Class A Static and Voyage Data | 129794 |
+| 14 | Safety-Related Broadcast | 129802 |
+| 18, 19 | Class B Position Report | 129039 |
+| 21 | Aid-to-Navigation Report | 129041 |
+| 24A | Class B Static Data (name) | 129809 |
+| 24B | Class B Static Data (type, callsign, dims) | 129810 |
+
+### Signal K Paths
+
+**Output (per-vessel/AtoN context):**
+- `navigation.position` — JSON: `{"longitude": X, "latitude": Y}`
+- `navigation.courseOverGroundTrue` — radians
+- `navigation.speedOverGround` — m/s
+- `navigation.headingTrue` — radians
+- `name` — vessel/AtoN name
+- `communication.callsignVhf` — callsign
+- `design.aisShipType` — integer type code
+- `navigation.destination.commonName` — destination
+
+**Input (from SK server, updates transponder):**
+- `navigation.destination.commonName` — destination
+- `navigation.destination.eta` — ISO 8601 timestamp
+- `communication.crewCount` — persons on board
 
 ## Dependencies
 
 - SensESP 3.2.0 — IoT framework (WiFi, web UI, Signal K)
 - SensESP/NMEA0183 — NMEA 0183 sentence parsing
-- NMEA2000-library — NMEA 2000 message handling
+- NMEA2000-library v4.17.2 — NMEA 2000 message handling
 - NMEA2000_twai — ESP32 TWAI (CAN) driver
-- Adafruit NeoPixel — RGB LED control
-- Adafruit SSD1306 — OLED display
-- elapsedMillis — Timing utilities
+- Adafruit SSD1306 v2.5.1 — OLED display
+- FastLED 3.9.4 — RGB LED (SK6805)
+- elapsedMillis v1.0.6 — Timing utilities
+- esp_websocket_client — WebSocket support (Espressif component)

--- a/README.md
+++ b/README.md
@@ -2,20 +2,23 @@
 
 ESP32-C3 firmware for the [HALSER](https://shop.hatlabs.fi/products/halser) board that bridges a **Matsutec HA-102** AIS transponder to NMEA 2000 and Signal K networks.
 
+This firmware serves as both a ready-to-use application and a reference example for building custom SensESP-based marine interface firmware.
+
 ## Features
 
-- Receives AIS data via NMEA 0183 at 38400 bit/s
+- Decodes AIS messages (Class A/B position and static data, safety messages, Aids to Navigation)
+- Forwards decoded AIS data to NMEA 2000 as standard PGNs
+- Outputs AIS target data to Signal K with per-vessel context
 - Configures Matsutec HA-102 transponder via web UI:
   - MMSI
   - Static ship data (name, callsign, antenna distances)
-  - Voyage data (ship type, draught, destination, etc.)
-- TCP server (port 10110) for raw NMEA 0183 sentence relay
-- TCP client for relaying AIS data to a Signal K server
-- OLED display showing hostname, IP, and uptime
+  - Voyage data (ship type, draught, destination, ETA, persons on board, navigational status)
+- Receive-only mode (disables transponder transmission while preserving configuration)
+- Bidirectional Signal K sync for destination, ETA, and crew count
+- OLED status display (hostname, IP address, uptime)
 - RGB LED activity indicator
-- NMEA 2000 network connectivity
 - OTA firmware updates
-- NMEA 2000 watchdog (optional)
+- NMEA 2000 watchdog with configurable auto-reboot
 
 ## Hardware Required
 
@@ -24,20 +27,215 @@ ESP32-C3 firmware for the [HALSER](https://shop.hatlabs.fi/products/halser) boar
 - NMEA 2000 network connection
 - Optional: SSD1306 128x64 OLED display (I2C)
 
+## Wiring
+
+| HALSER Pin | Function |
+|------------|----------|
+| GPIO 2 | UART1 TX → Matsutec RX |
+| GPIO 3 | UART1 RX ← Matsutec TX |
+| GPIO 4 | CAN TX → NMEA 2000 |
+| GPIO 5 | CAN RX ← NMEA 2000 |
+| GPIO 6 | I2C SDA (OLED display) |
+| GPIO 7 | I2C SCL (OLED display) |
+| GPIO 8 | RGB LED (SK6805) |
+| GPIO 9 | Button |
+
+The Matsutec HA-102 communicates via NMEA 0183 at 38,400 bit/s (8N1).
+
+## Usage
+
+### Initial Setup
+
+1. Flash the firmware to the HALSER board
+2. The device creates a WiFi access point on first boot
+3. Connect to the AP and configure your WiFi network credentials
+4. Access the web UI at `http://ais.local`
+
+### Configuring MMSI
+
+Navigate to the **MMSI** section in the web UI and enter your vessel's nine-digit MMSI. The firmware sends the configured MMSI to the transponder via the proprietary `$PAMC,C,MID` command.
+
+### Configuring Static Ship Data
+
+The **Static Ship Data** section lets you configure:
+
+- **Callsign** — VHF radio callsign (up to 7 characters)
+- **Ship Name** — vessel name (up to 20 characters)
+- **GNSS Antenna Distance to Bow/Stern/Port/Starboard** — antenna position relative to the hull (meters)
+
+These values are stored in the transponder and transmitted as part of the AIS static data.
+
+### Configuring Voyage Data
+
+The **Voyage Static Data** section lets you configure:
+
+- **Ship Type** — AIS ship type code (integer, e.g., 36 = sailing vessel)
+- **Maximum Draught** — vessel draught in meters
+- **Persons on Board** — crew count
+- **Destination** — destination port name
+- **Arrival Time** — estimated time of arrival (UTC)
+- **Navigational Status** — current status (e.g., 0 = under way using engine)
+
+Voyage data is also stored in the transponder. Some fields can be updated automatically from a Signal K server (see below).
+
+### Receive-Only Mode
+
+The **Operating Mode** section provides a **Receive Only** toggle. When enabled:
+
+- The firmware sends MMSI `000000000` to the transponder, which disables AIS transmission
+- The transponder continues to receive and forward AIS messages
+- Your configured MMSI is preserved and will be restored when you switch back to Transmit+Receive mode
+
+This is useful when you want to monitor AIS traffic without transmitting, for example during testing or in a marina.
+
+### Signal K Integration
+
+The firmware integrates with Signal K in two directions:
+
+**Output (AIS → Signal K):** Decoded AIS targets are emitted as Signal K deltas with per-vessel context (e.g., `vessels.urn:mrn:imo:mmsi:477553000`). Paths include `navigation.position`, `navigation.courseOverGroundTrue`, `navigation.speedOverGround`, `navigation.headingTrue`, `name`, `communication.callsignVhf`, `design.aisShipType`, and `navigation.destination.commonName`.
+
+**Input (Signal K → transponder):** The firmware listens to the Signal K server for updates to:
+- `navigation.destination.commonName` — updates the transponder's destination
+- `navigation.destination.eta` — updates the transponder's ETA (ISO 8601 format)
+- `communication.crewCount` — updates persons on board
+
+This allows other Signal K sources (e.g., a chart plotter or navigation app) to automatically update the transponder's voyage data.
+
+### NMEA 2000 Watchdog
+
+An optional watchdog can be enabled in the web UI under **NMEA 2000 Watchdog**. When enabled, the device reboots if no NMEA 2000 messages are received for two minutes. This helps recover from CAN bus lockups. The setting requires a device restart to take effect.
+
+### OLED Display
+
+If connected, a 128x64 SSD1306 OLED display shows:
+- Line 1: Device hostname
+- Line 2: WiFi IP address
+- Line 3: Uptime in seconds
+
+## Supported AIS Message Types
+
+| AIS Type | Description | NMEA 2000 PGN |
+|----------|-------------|----------------|
+| 1, 2, 3 | Class A Position Report | 129038 |
+| 5 | Class A Static and Voyage Data | 129794 |
+| 14 | Safety-Related Broadcast | 129802 |
+| 18, 19 | Class B Position Report | 129039 |
+| 21 | Aid-to-Navigation Report | 129041 |
+| 24 Part A | Class B Static Data (name) | 129809 |
+| 24 Part B | Class B Static Data (ship type, callsign, dimensions) | 129810 |
+
+## Architecture
+
+```
+Matsutec HA-102 (NMEA 0183, 38,400 bit/s)
+  │
+  │ UART1 (GPIO 3 RX / GPIO 2 TX)
+  ▼
+NMEA0183IOTask
+  ├── Matsutec config parsers (MMSI, ship data, voyage data)
+  ├── RMC parser (GNSS time sync)
+  └── AIS VDM/VDO parser
+        └── AISReassembler (multi-part message assembly)
+              └── AIS Decoder (6-bit binary → typed structs)
+                    ├── N2K Senders → NMEA 2000 bus (TWAI, GPIO 4/5)
+                    └── SK Output  → Signal K server (per-vessel context)
+
+Web UI (SensESP) ──── Config objects ──── Matsutec (serial commands)
+                                     └── Filesystem (voyage data backup)
+
+Signal K server ──── SKValueListeners ──── Voyage data config ──── Matsutec
+```
+
+The firmware is built on [SensESP](https://github.com/SignalK/SensESP), which provides WiFi connectivity, a web UI for configuration, Signal K protocol support, and OTA updates. The AIS decoding layer (`src/ais/`) is framework-agnostic and has no SensESP or Arduino dependencies, making it reusable in other projects.
+
+### Key Design Patterns
+
+**Producer/Consumer pipeline:** SensESP uses a reactive pipeline where producers emit values that flow to connected consumers. The AIS VDM parser is a producer of typed message structs that are consumed by N2K senders and Signal K outputs. Producers and consumers are connected via `connect_to()`.
+
+**Configuration as transponder state:** Unlike typical embedded configs stored in flash, the Matsutec configuration (MMSI, ship data) lives in the transponder itself. The config objects query the transponder on startup and send commands on save, using an async request/response pattern with timeout handling.
+
+**Contextual Signal K output:** Standard SensESP outputs emit to a fixed Signal K path for the local vessel. AIS data needs dynamic context — each target vessel gets its own Signal K context based on MMSI. The `SKContextualOutput` class extends SensESP to support this.
+
+## Code Structure
+
+### AIS Decoding (`src/ais/`)
+
+Framework-agnostic AIS message decoding with no Arduino/SensESP dependencies:
+
+| File | Purpose |
+|------|---------|
+| `ais_message_types.h` | Data structs for 6 AIS message types |
+| `ais_decoder.h/.cpp` | Binary payload decoding (ITU 6-bit armored → typed structs) |
+| `ais_reassembler.h/.cpp` | Multi-part VDM sentence reassembly with timeout |
+| `ais_vdm_fields.h` | VDM sentence field extraction and decode orchestration |
+| `ais_vdm_parser.h` | SensESP `SentenceParser` integration with per-message-type producer outputs |
+| `ais_conversions.h` | Unit conversions (AIS → NMEA 2000 / SI units) |
+
+### Matsutec Configuration (`src/`)
+
+| File | Purpose |
+|------|---------|
+| `matsutec_config.h` | Config objects for MMSI, ship data, voyage data (query/set via serial) |
+| `matsutec_ha102_parser.h` | Parsers for proprietary Matsutec response sentences |
+| `operating_mode.h` | Framework-agnostic TX/RX mode state machine |
+| `operating_mode_config.h` | SensESP config wrapper for operating mode |
+
+### Output (`src/sender/`, `src/signalk/`)
+
+| File | Purpose |
+|------|---------|
+| `sender/ais_n2k_senders.h` | AIS → NMEA 2000 PGN senders (one class per message type) |
+| `signalk/sk_ais_output.h` | AIS → Signal K contextual output mapper |
+| `signalk/sk_contextual_output.h` | SensESP extension for dynamic Signal K context |
+
+### Application
+
+| File | Purpose |
+|------|---------|
+| `main.cpp` | Application entry point — wires all components together |
+| `ssd1306_display.h/.cpp` | OLED display driver (hostname, IP, uptime) |
+
 ## Building
 
 Requires [PlatformIO](https://platformio.org/).
 
 ```bash
-# Build
+# Build firmware
 pio run
 
-# Upload
+# Upload to connected board
 pio run -t upload
 
 # Monitor serial output
 pio device monitor
 ```
+
+## Testing
+
+Unit tests run on the native (x86_64) platform:
+
+```bash
+# Run all tests
+pio test -e native
+```
+
+Test suites cover AIS decoding, unit conversions, multi-part reassembly, VDM field parsing, Signal K output, and operating mode logic.
+
+## Using as a Template
+
+This firmware demonstrates several patterns useful for building custom SensESP marine interfaces:
+
+1. **NMEA 0183 sentence parsing** — Custom `SentenceParser` subclasses for proprietary and standard sentences
+2. **NMEA 2000 output** — `ValueConsumer` classes that convert parsed data to N2K PGNs
+3. **Signal K contextual output** — Emitting data to dynamic Signal K contexts (per-vessel, per-AtoN)
+4. **External device configuration** — Query/response config pattern with async timeout handling
+5. **Framework-agnostic core logic** — Keeping protocol decoding independent of the IoT framework for testability
+
+To adapt this for a different device:
+- Replace the Matsutec parsers and config classes with your device's protocol
+- Modify the AIS decoder if supporting different message types
+- Update the N2K sender classes for your target PGNs
+- Adjust pin assignments in `main.cpp`
 
 ## License
 

--- a/src/ais/ais_decoder.cpp
+++ b/src/ais/ais_decoder.cpp
@@ -1,3 +1,14 @@
+// AIS binary payload decoder.
+//
+// AIS messages are transmitted as NMEA 0183 VDM sentences with payloads
+// encoded in ITU-R M.1371 "armored" 6-bit ASCII. Each printable character
+// maps to a 6-bit value (subtract 48; if > 40, subtract 8 more). The
+// resulting bitstream contains fixed-width fields extracted by bit offset.
+//
+// This module decodes the armored payload into typed message structs.
+// It handles 6 message categories (1/2/3, 5, 14, 18/19, 21, 24) with proper
+// handling of special "not available" sentinel values (NaN, 181.0°, etc.).
+
 #include "ais_decoder.h"
 
 #include <cmath>
@@ -84,8 +95,8 @@ static bool decode_class_a_position(const uint8_t* payload, int num_bits,
   if (rot_raw == -128) {
     out.rot = NAN;
   } else {
-    // ROT = 4.733 * sqrt(ROT_sensor), stored as ROT_AIS
-    // We store the raw value in deg/min for simplicity
+    // ITU-R M.1371: ROT_AIS = 4.733 * sqrt(ROT_sensor_deg_per_min)
+    // Invert to get deg/min: ROT_sensor = sign * (|ROT_AIS| / 4.733)^2
     double rot_sign = rot_raw < 0 ? -1.0 : 1.0;
     double rot_abs = static_cast<double>(rot_raw < 0 ? -rot_raw : rot_raw);
     out.rot = rot_sign * (rot_abs / 4.733) * (rot_abs / 4.733);

--- a/src/ais/ais_vdm_parser.h
+++ b/src/ais/ais_vdm_parser.h
@@ -11,7 +11,12 @@ namespace ais {
 
 // SentenceParser for AIS VDM (received) and VDO (own ship) sentences.
 // Delegates field parsing and decoding to parse_vdm_fields() and dispatches
-// decoded messages to typed ObservableValue outputs.
+// decoded messages to typed producer outputs.
+//
+// Usage: connect consumers to the public output members using the SensESP
+// Producer/Consumer pattern. Example:
+//   auto parser = std::make_shared<AISVDMSentenceParser>(&nmea_parser);
+//   parser->class_a_position_.connect_to(my_position_consumer);
 class AISVDMSentenceParser : public sensesp::nmea0183::SentenceParser {
  public:
   AISVDMSentenceParser(sensesp::nmea0183::NMEA0183Parser* nmea,
@@ -40,7 +45,7 @@ class AISVDMSentenceParser : public sensesp::nmea0183::SentenceParser {
         result.value());
   }
 
-  // Observable outputs — one per AIS message type
+  // Producer outputs — one per AIS message type
   sensesp::ObservableValue<ClassAPositionReport> class_a_position_;
   sensesp::ObservableValue<ClassBPositionReport> class_b_position_;
   sensesp::ObservableValue<ClassAStaticData> class_a_static_;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,15 @@
 // HALSER AIS Interface Firmware
-// Matsutec HA-102 AIS transponder to NMEA 2000 gateway
+//
+// Application entry point that wires together the data pipeline:
+//   Matsutec HA-102 (NMEA 0183) → AIS decoder → N2K senders + Signal K output
+//
+// Configuration (MMSI, ship data, voyage data) lives in the transponder,
+// not on the ESP32. Config objects query the transponder on startup and
+// send commands on save, using an async request/response pattern.
+//
+// Signal K integration is bidirectional: decoded AIS targets are emitted
+// to the SK server, while destination/ETA/crew updates from the SK server
+// are forwarded to the transponder's voyage data.
 
 #include <NMEA2000_esp32.h>
 #include <sys/time.h>
@@ -197,6 +207,9 @@ void setup() {
 
   /////////////////////////////////////////////////////////////////////
   // Signal K voyage data input — receive updates from SK server
+  // These listeners enable bidirectional sync: when a navigation app
+  // sets the destination or ETA on the SK server, the transponder
+  // is updated automatically so AIS broadcasts reflect the change.
 
   auto sk_destination_listener = std::make_shared<SKValueListener<String>>(
       "navigation.destination.commonName", 5000);

--- a/src/matsutec_config.h
+++ b/src/matsutec_config.h
@@ -1,3 +1,19 @@
+// Matsutec HA-102 transponder configuration via proprietary NMEA 0183 sentences.
+//
+// Configuration (MMSI, ship data, voyage data) is stored in the transponder,
+// not on the ESP32 filesystem. Each config class follows a query/response
+// pattern:
+//   1. On startup (load/refresh): send a query sentence, activate an
+//      AsyncResponseHandler, and wait for the transponder's response
+//      (or a 3-second timeout).
+//   2. On save: send a set sentence with the new values and verify
+//      the transponder echoes them back.
+//
+// Sentence formats:
+//   MMSI:       $PAMC,Q,MID  /  $PAMC,C,MID,<mmsi>,000000000
+//   Ship data:  $ECAIQ,SSD   /  $AISSD,<callsign>,<name>,<bow>,<stern>,<port>,<stbd>,0,
+//   Voyage:     $ECAIQ,VSD   /  $AIVSD,<type>,<draught>,<persons>,<dest>,<HHMMSS>,<day>,<month>,<status>,<flags>
+
 #ifndef AIS_INTERFACE_SRC_MATSUTEC_CONFIG_H_
 #define AIS_INTERFACE_SRC_MATSUTEC_CONFIG_H_
 

--- a/src/operating_mode.h
+++ b/src/operating_mode.h
@@ -1,3 +1,11 @@
+// Receive-only mode for the Matsutec HA-102 transponder.
+//
+// The HA-102 doesn't have an explicit "receive only" command. Instead,
+// setting the MMSI to 000000000 effectively disables AIS transmission
+// while allowing reception to continue. The user's configured MMSI is
+// preserved in memory so it can be restored when switching back to
+// transmit+receive mode.
+
 #ifndef OPERATING_MODE_H_
 #define OPERATING_MODE_H_
 

--- a/src/sender/ais_n2k_senders.h
+++ b/src/sender/ais_n2k_senders.h
@@ -1,3 +1,14 @@
+// AIS → NMEA 2000 message senders.
+//
+// Each sender is a consumer in the SensESP Producer/Consumer pipeline:
+// it receives a decoded AIS struct, converts it to the corresponding
+// N2K PGN, and transmits it on the CAN bus. Connect these to the
+// AISVDMSentenceParser's producer outputs via connect_to().
+//
+// Note: AISClassAStaticN2kSender requires a valid system clock (from GNSS
+// time sync) to resolve the ETA year. Before sync, ETA is sent as "not
+// available" to avoid broadcasting incorrect dates.
+
 #ifndef AIS_N2K_SENDERS_H_
 #define AIS_N2K_SENDERS_H_
 

--- a/src/signalk/sk_ais_output.h
+++ b/src/signalk/sk_ais_output.h
@@ -11,9 +11,13 @@
 namespace ais {
 
 // Wires AIS VDM parser outputs to Signal K contextual outputs.
-// Creates one SKContextualOutput per SK path and provides
+//
+// Standard SensESP SKOutput emits to a fixed path for the local vessel.
+// AIS data requires dynamic context — each target vessel gets its own
+// Signal K context based on MMSI (e.g., vessels.urn:mrn:imo:mmsi:477553000).
+// This class creates one SKContextualOutput per SK path and provides
 // LambdaConsumer instances that transform AIS structs into
-// (context, value) pairs.
+// (context, value) pairs for the correct vessel or AtoN.
 class SKAISOutput {
  public:
   SKAISOutput() {


### PR DESCRIPTION
## Summary

- Expand README from minimal feature list to full usage guide covering configuration, receive-only mode, Signal K integration, architecture, code structure, and template guidance for developers
- Rewrite CLAUDE.md: fix stale file references (removed TCP files that no longer exist), add complete source layout, Matsutec protocol examples, AIS message type table, Signal K path docs
- Add targeted "why" comments to 7 source files explaining key design decisions (transponder-stored config, zero-MMSI receive-only mechanism, ITU 6-bit encoding, Producer/Consumer pipeline, ETA clock dependency, contextual Signal K output)

## Test plan

- [x] `pio run` — firmware compiles successfully
- [x] `pio test -e native` — all 69 tests pass
- [x] All CLAUDE.md file references verified against actual files on disk
- [ ] Review README rendering on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)